### PR TITLE
Add existing redirect from docs.ubuntu.com

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,3 @@
+# Pages redirects:
+# On 12/01/2017
+core/en/guides/build-device/assertions: /core/en/reference/assertions


### PR DESCRIPTION
Add a redirect from the redirects file on https://github.com/canonical-websites/docs.ubuntu.com

# QA

- `./run`
- Visit http://localhost:8001/core/en/guides/build-device/assertions and be redirected to http://localhost:8001/core/en/reference/assertions