### PR TITLE
Update the watch command to actually build the docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "scripts": {
     "clean-git-repos": "cd docs/en/stacks; rm -rf audio/alsa-utils/ audio/pulseaudio/ bluetooth/bluez/ disk/udisks2/ location/location-service/ network/easy-openvpn/ network/modem-manager/ network/network-manager/ network/wpa-supplicant/ network/wifi-ap/ power/upower/ utilities/developer/",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle .repo en .extra; yarn run clean-git-repos",
-    "watch": "watch -p 'docs/**/*.md' -c 'yarn run build-css'",
+    "watch": "watch -p 'docs/**/*.md' -c 'yarn run build-docs'",
     "build-repo": "git config --global user.email 'you@example.com' && git config --global user.name 'Your Name' && git config --global color.ui false && ./bin/repo --trace  init --manifest-url \"$(./bin/get-manifest-url)\" --manifest-branch \"$(git rev-parse HEAD)\" && ./bin/repo sync",
-    "build": "yarn run build-repo && documentation-builder --base-directory docs --output-path templates --output-media-path 'static/media/core' --media-url '/static/media/core' --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.ubuntu.com/core' --search-url '/search' --search-placeholder 'Search Ubuntu Core docs' --no-link-extensions",
+    "build-docs": "documentation-builder --base-directory docs --output-path templates --output-media-path 'static/media/core' --media-url '/static/media/core' --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.ubuntu.com/core' --search-url '/search' --search-placeholder 'Search Ubuntu Core docs' --no-link-extensions",
+    "build": "yarn run build-repo && yarn run build-docs",
     "test": "",
     "serve": "cd dist && FLASK_DEBUG=true FLASK_APP=app.py flask run -h 0.0.0.0 -p $PORT"
   },


### PR DESCRIPTION
This replaces the missing `build-css` command by a `build-docs` one.

To both serve the site and watch for updates:

1. In a first terminal tab, run `./run`
2. In another one, run `./run watch`