### PR TITLE
Updated image building doc for Core 18

### DIFF
--- a/docs/en/guides/build-device/image-building.md
+++ b/docs/en/guides/build-device/image-building.md
@@ -74,7 +74,7 @@ To build an image, it is required you have a signed model assertion.
 
 ### Example
 
-The following is an example model assertion that builds a Core 18 image for a Raspberry Pi 3 (or Compute Module 3) board. The JSON file is named `pi3-model.json`:
+The following is an example model assertion that builds a Core 18 image for a Raspberry Pi 3 board. The JSON file is named `pi3-model.json`:
 
 ```json
 {
@@ -85,8 +85,8 @@ The following is an example model assertion that builds a Core 18 image for a Ra
   "model": "my-pi3",
   "architecture": "armhf",
   "base": "core18",
-  "gadget": "pi=18-cm3",
-  "kernel": "pi-kernel=18-cm3",
+  "gadget": "pi=18-pi3",
+  "kernel": "pi-kernel=18-pi3",
   "timestamp": "<timestamp>"
 }
 ```

--- a/docs/en/guides/build-device/image-building.md
+++ b/docs/en/guides/build-device/image-building.md
@@ -51,7 +51,7 @@ Your keys are located within *~/.snap/gnupg*, and it's a good idea to keep a bac
 
 ### 2. Register the key with the store
 
-With the key created, you now need to register it with the store, effectively linking it to your account. During this step, you will be asked to select an existing key (if you have more than one) and login with your store account credentials:
+With the key created, you now need to register it with the store, effectively linking it to your account. During this step, you will be asked to select an existing key (if you have more than one) and log in with your store account credentials:
 
 ```
 snapcraft register-key

--- a/docs/en/guides/build-device/image-building.md
+++ b/docs/en/guides/build-device/image-building.md
@@ -38,7 +38,7 @@ snapcraft create-key foo
 
 The *create-key* command will ask you for a password to protect the key.
 
-Generating the key will take some time because it's creating a 4096 bit long key that needs some entropy to complete. To speed up the process, you can install the `rng-tools` package beforehand.
+Generating the key will take some time because it's creating a 4096 bit long key that needs some entropy to complete. Moving the mouse or typing can help to speed up the process, as will installing the `rng-tools` package beforehand.
 
 Now, you can list your keys with:
 

--- a/docs/en/guides/build-device/image-building.md
+++ b/docs/en/guides/build-device/image-building.md
@@ -97,7 +97,7 @@ The following is an example model assertion that builds a Core 18 image for a Ra
 *   `architecture`: the architecture of the device you are building the image for.
 *   `base`: the runtime environment to use.
 *   `gadget` and `kernel` refer to snaps already existing in the store or in the current directory.
-*   `=18-cm3`, appended to *gadget* and *kernel*, defines the channel to track. For the universal *pi* snaps, these denote channels for specific models.
+*   `=18-pi3`, appended to *gadget* and *kernel*, defines the channel to track. For the universal *pi* snaps, these denote channels for specific models.
 *   `timestamp` is a valid timestamp you need to generate using the `date -Iseconds --utc` command. The timestamp must be later than when the key that signs the model was registered.
 *   `required-snaps`: you can optionally add a list of required snaps that will be unremovable and will be downloaded from the store or locally if they exist in the current directory
 

--- a/docs/en/guides/build-device/image-building.md
+++ b/docs/en/guides/build-device/image-building.md
@@ -66,7 +66,7 @@ An Ubuntu Core image is composed of at least three snaps installed together: OS,
 *   The OS snap contains *Ubuntu Core* itself and will be downloaded during image creation.
 *   The kernel and gadget snaps are layers to personalise or enable your target device. They can be locally built or pulled from the store if they already exist.
 
-The composition of your image is described through a "model assertion", a JSON document signed with your key.
+A *model assertion*, defined within a JSON-formatted file and consumed by the build process, is used to configure your image.
 
 ### 1. Create a model assertion
 
@@ -101,14 +101,14 @@ The following is an example model assertion that builds a Core 18 image for a Ra
 *   `timestamp` is a valid timestamp you need to generate using the `date -Iseconds --utc` command. The timestamp must be later than when the key that signs the model was registered.
 *   `required-snaps`: you can optionally add a list of required snaps that will be unremovable and will be downloaded from the store or locally if they exist in the current directory
 
-To alternatively build an Ubuntu Core 16 image, replace the `build`, `gadget` and `kernel` lines with the following:
+To alternatively build an Ubuntu Core 16 image, replace the `base`, `gadget` and `kernel` lines with the following:
 
 ```json
   "gadget": "pi3",
   "kernel": "pi2-kernel",
 ```
 
-**Note**: There are additional requirements when the image targets a Brand Store. Use your Brand SSO Account's account-id in the the `authority-id` and `brand-id` fields. Also add a `store` key whose value is your Brand `store-id`. 
+**Note**: There are additional requirements when the image targets a Brand Store. Use your Brand SSO Account's account-id in the `authority-id` and `brand-id` fields. Also add a `store` key whose value is your Brand `store-id`. 
 
 ### 2. Sign your model assertion
 

--- a/docs/en/guides/build-device/image-building.md
+++ b/docs/en/guides/build-device/image-building.md
@@ -5,62 +5,68 @@ table_of_contents: true
 
 # Ubuntu Core images
 
-Official Ubuntu Core images for supported devices can be found [here](http://cdimage.ubuntu.com/ubuntu-core/16/stable).
-
-[Install Ubuntu Core on your device &rsaquo;](https://developer.ubuntu.com/en/snappy/start/)
+For [supported devices](https://developer.ubuntu.com/core/get-started), there are official Ubuntu Core images for both [Core 18](http://cdimage.ubuntu.com/ubuntu-core/18/stable/) and [Core 16](http://cdimage.ubuntu.com/ubuntu-core/18/stable/).
 
 ## Build a custom Ubuntu Core image
 
-This document will walk you through all the steps to build an image for a device family. You will learn how to:
+This document will walk you through the steps needed to build either a Core 18 or Core 16 image for a device family. You will learn how to:
 
 *   Create and upload a snapcraft key to the store
 *   Create a model assertion for your target device
 *   Compose and build a custom image using the `ubuntu-image` command
 
-If you want to build an Ubuntu Core image for a board that is not already supported, please follow the [Board enablement overview](../../guides/build-device/board-enablement.html) document.
+If you want to build an Ubuntu Core image for a device family that is not already supported, please follow the [Board enablement overview](../../guides/build-device/board-enablement.html) document.
 
 ## Snapcraft keys
 
-Before starting with building the image, you need to create a key to sign your future store uploads.
+Before starting, you need to create a key to sign your future store uploads.
 
 
 ### 1. Create a key
 
-**Note**: If you are building an image to work with a Brand Store, you need to use the Brand SSO account for these steps. You can use `snapcraft logout`. Then use `snapcraft login` and provide the Brand SSO Account credentials to login.  
+To generate a key that can then be linked to your Ubuntu Store account, run the following:
 
-As a first step, you have to generate a key that will be linked to your Ubuntu Store account. To do so, run:
-
-
-    snapcraft create-key
+```bash
+snapcraft create-key
+```
 
 You can pass an optional name for the key:
 
-    snapcraft create-key foo
+```bash
+snapcraft create-key foo
+```
 
-This command will ask you for a password to protect the key.
+The *create-key* command will ask you for a password to protect the key.
 
-It will take some time, as it's creating a 4096 bit long key and needs some entropy to complete. To speed up the process, you can install the `rng-tools` package beforehand.
+Generating the key will take some time because it's creating a 4096 bit long key that needs some entropy to complete. To speed up the process, you can install the `rng-tools` package beforehand.
 
 Now, you can list your keys with:
 
-    snapcraft list-keys
+```bash
+snapcraft list-keys
+```
+
+Your keys are located within *~/.snap/gnupg*, and it's a good idea to keep a backup of this directory.
+
 
 ### 2. Register the key with the store
 
-Next, you have to register the key with the store, effectively linking it to your account. During this step, you will be asked to select an existing key and login with your store account credentials.
+With the key created, you now need to register it with the store, effectively linking it to your account. During this step, you will be asked to select an existing key (if you have more than one) and login with your store account credentials:
 
-    snapcraft register-key
+```
+snapcraft register-key
+```
 
 The key is now registered with the store and you can start the actual image building.
 
 ## Image building
 
-An ubuntu-core image is composed of at least three snaps installed together: OS, gadget and kernel.
+An Ubuntu Core image is composed of at least three snaps installed together: OS, gadget and kernel.
 
-*   The OS snap contains ubuntu-core itself and will be downloaded during image creation.
-*   The kernel and gadget snaps are layers to personalize or enable your target device. They can be locally built or pulled from the store if they already exist.
+*   The OS snap contains *Ubuntu Core* itself and will be downloaded during image creation.
+*   The kernel and gadget snaps are layers to personalise or enable your target device. They can be locally built or pulled from the store if they already exist.
 
-The composition of your image is described through a "model assertion", a signed JSON document.
+The composition of your image is described through a "model assertion", a JSON document signed with your key.
 
 ### 1. Create a model assertion
 
@@ -68,55 +74,69 @@ To build an image, it is required you have a signed model assertion.
 
 ### Example
 
+The following is an example model assertion that builds a Core 18 image for a Raspberry Pi 3 / Compute Module 3 board. The JSON file is named `pi3-model.json`:
 
-As an example, here is one for a device based on a Raspberry Pi 3 board. The JSON file is named `pi3-model.json`, with the following content:
+```json
+{
+  "type": "model",
+  "authority-id": "<your account id>",
+  "brand-id": "<your account id>",
+  "series": "16",
+  "model": "my-pi3",
+  "architecture": "armhf",
+  "base": "core18",
+  "gadget": "pi=18-cm3",
+  "kernel": "pi-kernel=18-cm3",
+  "timestamp": "<timestamp>"
+}
+```
 
-    {
-      "type": "model",
-      "authority-id": "<your account id>",
-      "brand-id": "<your account id>",
-      "series": "16",
-      "model": "my-pi3",
-      "architecture": "armhf",
-      "gadget": "pi3",
-      "kernel": "pi2-kernel",
-      "timestamp": "<timestamp>"
-    }
-
-*   `authority-id`, `brand-id` are your Ubuntu SSO account ID. See [your account page](https://dashboard.snapcraft.io/dev/account/), in the `Account-Id` field.
-*   `series`: the Ubuntu Core series in use
+*   `authority-id` and `brand-id` are your Ubuntu SSO account ID. See [your account page](https://dashboard.snapcraft.io/dev/account/), in the `Account-Id` field.
+*   `series`: the version of the assertion format, and snap namespaces, being used. Later series are backwards compatible.
 *   `model`: a free form lower-case name for your target device. 
-*   `architecture`: the architecture of the device you are building the image for
-*   `gadget` and `kernel` refer to snaps already existing in the store or in the current directory
+*   `architecture`: the architecture of the device you are building the image for.
+*   `base`: the runtime environment to use.
+*   `gadget` and `kernel` refer to snaps already existing in the store or in the current directory.
+*   `=18-cm3`, appended to *gadget* and *kernel*, defines the channel to track. For the universal *pi* snaps, these denote channels for specific models.
 *   `timestamp` is a valid timestamp you need to generate using the `date -Iseconds --utc` command. The timestamp must be later than when the key that signs the model was registered.
 *   `required-snaps`: you can optionally add a list of required snaps that will be unremovable and will be downloaded from the store or locally if they exist in the current directory
+
+To alternatively build an Ubuntu Core 16 image, replace the `build`, `gadget` and `kernel` lines with the following:
+
+```json
+  "gadget": "pi3",
+  "kernel": "pi2-kernel",
+```
 
 **Note**: There are additional requirements when the image targets a Brand Store. Use your Brand SSO Account's account-id in the the `authority-id` and `brand-id` fields. Also add a `store` key whose value is your Brand `store-id`. 
 
 ### 2. Sign your model assertion
 
-Now you have to sign the model assertion with a key, by piping your JSON model
-through the `snap sign -k <key name>` command and outputting a model file, the
-actual assertion document you will use to build your image.
+Now you have to sign the model assertion with a key by piping your JSON model through the `snap sign -k <key name>` command. The output is the assertion document you will use to build your image.
 
 **Note**: If the model is for a Brand Store, the key must be registered by the Brand SSO Account. 
 
-    cat pi3-model.json | snap sign -k default &> pi3.model
+```bash
+cat pi3-model.json | snap sign -k default &> pi3.model
+```
 
-This command will ask you for the password you used on key creation to secure
-the key.
+This command will ask you for the password used when you created the key.
+
+You can check the signing process has worked by ensuring the signed key has been appended to *pi3.model*.
 
 ### 3. Build the image
 
-You can now create your image with the `ubuntu-image` tool.
+You can now create your image with the `ubuntu-image` tool. To install it, run:
 
-To install it, run:
-
-    snap install --beta --devmode ubuntu-image
+```bash
+snap install --classic ubuntu-image
+```
 
 Then, create the image:
 
-    sudo ubuntu-image -c beta -O pi3-test pi3.model
+```bash
+sudo ubuntu-image -c beta -O pi3-test pi3.model
+```
 
 #### Arguments
 
@@ -125,16 +145,20 @@ Then, create the image:
 
 You can include specific snaps pre-installed by default in the image by using the `--extra-snaps` argument. For example:
 
-    sudo ubuntu-image -c beta --extra-snaps rocketchat-server --extra-snaps nextcloud -o pi3-test.img pi3.model
+```bash
+sudo ubuntu-image -c beta --extra-snaps rocketchat-server --extra-snaps nextcloud -o pi3-test.img pi3.model
+```
 
 Note: The `--extra-snaps` argument takes either a snap name accessible from the store or a local path to a built snap.
 
 ### 4. Your image is ready
 
-You can use a tool like `dd` to write the image to an SDcard and boot your device.
+You can use a tool like `dd` to write the image to an SD card and boot your device (replace *sdXX* with the node for your storage device):
 
-    sudo dd if=pi3-test.img of=/dev/sdb bs=32M
-    sync
+```bash
+sudo dd if=pi3-test/pi3.img of=/dev/sdXX bs=32M
+sync
+```
 
 #### First boot tips
 
@@ -145,3 +169,4 @@ You can use a tool like `dd` to write the image to an SDcard and boot your devic
 #### Known problems and limitations:
 
 *   You need a monitor or a serial cable plugged to the device to be able to go through the first use setup process handled by `console-conf`.
+

--- a/docs/en/guides/build-device/image-building.md
+++ b/docs/en/guides/build-device/image-building.md
@@ -5,7 +5,7 @@ table_of_contents: true
 
 # Ubuntu Core images
 
-For [supported devices](https://developer.ubuntu.com/core/get-started), there are official Ubuntu Core images for both [Core 18](http://cdimage.ubuntu.com/ubuntu-core/18/stable/) and [Core 16](http://cdimage.ubuntu.com/ubuntu-core/18/stable/).
+For [supported devices](https://developer.ubuntu.com/core/get-started), there are official Ubuntu Core images for both [Core 18](http://cdimage.ubuntu.com/ubuntu-core/18/stable/) and [Core 16](http://cdimage.ubuntu.com/ubuntu-core/16/stable/).
 
 ## Build a custom Ubuntu Core image
 

--- a/docs/en/guides/build-device/image-building.md
+++ b/docs/en/guides/build-device/image-building.md
@@ -74,7 +74,7 @@ To build an image, it is required you have a signed model assertion.
 
 ### Example
 
-The following is an example model assertion that builds a Core 18 image for a Raspberry Pi 3 / Compute Module 3 board. The JSON file is named `pi3-model.json`:
+The following is an example model assertion that builds a Core 18 image for a Raspberry Pi 3 (or Compute Module 3) board. The JSON file is named `pi3-model.json`:
 
 ```json
 {


### PR DESCRIPTION
- updated to default to Core 18 image building
- added Core 16 attributes as an alternative
- brief overall edit for consistency and small fixes

(tested the process for core 18 and core 16 on a RPi 3)

@mvo5 @pedronis